### PR TITLE
Fixed reference to undefined variable

### DIFF
--- a/k8s/rke2/rke2-terraform/masters.tf
+++ b/k8s/rke2/rke2-terraform/masters.tf
@@ -135,7 +135,7 @@ module "masters_asg" {
       value = var.environment
     },
     {
-      key   = "kubernetes.io/cluster/${var.cluster_name}"
+      key   = "kubernetes.io/cluster/${var.environment}"
       value = "owned"
     }
   ]

--- a/k8s/rke2/rke2-terraform/workers.tf
+++ b/k8s/rke2/rke2-terraform/workers.tf
@@ -42,7 +42,7 @@ module "workers_asg" {
       value = var.environment
     },
     {
-      key   = "kubernetes.io/cluster/${var.cluster_name}"
+      key   = "kubernetes.io/cluster/${var.environment}"
       value = "owned"
     }
   ]


### PR DESCRIPTION
This hcl failed to validate as it referenced an undefined variable `cluster_name`.

Since `environment` is described as "_Cluster name label to be used in tags, as well as a prefix for various resource names (for example prevent IAM resources overlap)_" I replaced the bad references with this variable. 