### PR TITLE
NK-12382 stderr sent to dev/null which make issues related to aws client install hard to debug

### DIFF
--- a/k8s/eksd/eksd-terraform/get_existing_asg.sh
+++ b/k8s/eksd/eksd-terraform/get_existing_asg.sh
@@ -93,7 +93,7 @@ then
   fi
   curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
   unzip -qo awscliv2.zip
-  sudo ./aws/install 2>/dev/null || true
+  sudo ./aws/install 1>/dev/null || true
 fi
 EOF
 

--- a/k8s/eksd/infra-terraform/get_loadbalancer.sh
+++ b/k8s/eksd/infra-terraform/get_loadbalancer.sh
@@ -96,7 +96,7 @@ then
   fi
   curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
   unzip -qo awscliv2.zip
-  sudo ./aws/install 2>/dev/null || true
+  sudo ./aws/install 1>/dev/null || true
 fi
 EOF
 


### PR DESCRIPTION
stderr is omitted therefore make it hard to debug issues related to aws client install as happened in NK-12382 within get_loadbalancer.sh.

issue looks relevant to "get_existing_asg.sh" too .